### PR TITLE
Use newer image for cloudwatch-agent

### DIFF
--- a/PrometheusDemo/ecs/ecs-cwagent-config.yml
+++ b/PrometheusDemo/ecs/ecs-cwagent-config.yml
@@ -267,7 +267,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: amazon/cloudwatch-agent:1.248913.0-prometheus
+          Image: amazon/cloudwatch-agent:1.247350.0b251780
           Essential: true
           MountPoints: []
           PortMappings: []


### PR DESCRIPTION
This version of cloud watch agent is a few years old.
In particular, the latest build has TaskId as a possible Dimension.

*Issue #, if available:*

*Description of changes:*

The example cloud watch agent image is very old.
I spend way too much time trying to figure out why TaskId, which I found in the source for the agent, wasn't showing up in CloudWatch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
